### PR TITLE
Remove --global from git config command

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -68,8 +68,8 @@
           <li>Optional, but recommended: Configure `git` so that it knows who
               you are:
 
-              <blockquote><code>git config --global user.name "&lt;Your Name Here!&gt;"</code></blockquote>
-              <blockquote><code>git config --global user.email "&lt;Your Email Address Here!&gt;"</code></blockquote>
+              <blockquote><code>git config user.name "&lt;Your Name Here!&gt;"</code></blockquote>
+              <blockquote><code>git config user.email "&lt;Your Email Address Here!&gt;"</code></blockquote>
 
               Make sure your email address is also added to your
               <a href="https://github.com/settings/emails">GitHub email list</a>


### PR DESCRIPTION
The instructions in node core were updated to use local (instead of global) git config in nodejs/node/pull/19777
Updating the same on NodeToDo in this PR