### PR TITLE
fix: modify color scheme for WCAG AA compliance

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 :root {
-  --teal: #14b8a6;
+  --teal: #28a496;
   --teal-link: #0d9488;
   --app-bg: #F6F7F9;
   --app-text: #0D121C;


### PR DESCRIPTION
The white h1 text on the teal background has a color contrast ratio lower than 3.0. Modify the teal color to get a contrast slightly over 3.0.